### PR TITLE
Add D9 Missing Config Variable.

### DIFF
--- a/github_cards.info.yml
+++ b/github_cards.info.yml
@@ -1,8 +1,7 @@
 name: 'GitHub Cards'
 type: module
 description: 'GitHub user and repo cards.'
-core_version_requirement: ^8
-core: 8.x
+core_version_requirement: ^8.9 || ^9
 package: 'GitHub'
 dependencies:
   - drupal:block


### PR DESCRIPTION
Added the Drupal `core_version_requirement` variable to validate that this module is ready for Drupal 9. With this, the module passes Drupal's D9 Ready steps.

Locally tested installing this module on a D9 site and it was able to be installed and used successfully.